### PR TITLE
Add support for tracking external environment (#927)

### DIFF
--- a/bits_helpers/build.py
+++ b/bits_helpers/build.py
@@ -185,7 +185,11 @@ def storeHashes(package, specs, considerRelocation):
     for _, _, hasher in h_alternatives:
       hasher(data)
 
-  for key in ("env", "append_path", "prepend_path"):
+  modifies_full_hash_dicts = ["env", "append_path", "prepend_path"]
+  if not spec["is_devel_pkg"] and "track_env" in spec:
+    modifies_full_hash_dicts.append("track_env")
+
+  for key in modifies_full_hash_dicts:
     if key not in spec:
       h_all("none")
     else:
@@ -267,6 +271,19 @@ def hash_local_changes(spec):
   class UntrackedChangesError(Exception):
     """Signal that we cannot detect code changes due to untracked files."""
   h = Hasher()
+  if "track_env" in spec:
+    assert isinstance(spec["track_env"], OrderedDict), \
+        "spec[%r] was of type %r" % ("track_env", type(spec["track_env"]))
+
+    # Python 3.12 changed the string representation of OrderedDicts from
+    # OrderedDict([(key, value)]) to OrderedDict({key: value}), so to remain
+    # compatible, we need to emulate the previous string representation.
+    h("OrderedDict([")
+    h(", ".join(
+        # XXX: We still rely on repr("str") being "'str'",
+        # and on repr(["a", "b"]) being "['a', 'b']".
+        "(%r, %r)" % (key, value) for key, value in spec["track_env"].items()))
+    h("])")
   def hash_output(msg, args):
     lines = msg % args
     # `git status --porcelain` indicates untracked files using "??".
@@ -1050,6 +1067,9 @@ def doBuild(args, parser):
     ]
     # Add the extra environment as passed from the command line.
     buildEnvironment += [e.partition('=')[::2] for e in args.environment]
+
+    # Add the computed track_env environment
+    buildEnvironment += [(key, value) for key, value in spec.get("track_env", {}).items()]
 
     # In case the --docker options is passed, we setup a docker container which
     # will perform the actual build. Otherwise build as usual using bash.

--- a/bits_helpers/utilities.py
+++ b/bits_helpers/utilities.py
@@ -460,6 +460,7 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
   failedRequirements = set()
   testCache = {}
   requirementsCache = {}
+  trackingEnvCache = {}
   packages = packages[:]
   validDefaults = []  # empty list: all OK; None: no valid default; non-empty list: list of valid ones
 
@@ -534,6 +535,15 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
       noSystemList = noSystem.split(",")
     systemExcluded = (spec["package"] in noSystemList)
     allowSystemPackageUpload = spec.get("allow_system_package_upload", False)
+    # Fill the track env with the actual result from executing the script.
+    for env, trackingCode in spec.get("track_env", {}).items():
+      key = spec["package"] + env
+      if key not in trackingEnvCache:
+        status, out = performPreferCheck(spec, trackingCode)
+        dieOnError(status, "Error while executing track_env for {}: {} => {}".format(key, trackingCode, out))
+        trackingEnvCache[key] = out
+      spec["track_env"][env] = trackingEnvCache[key]
+
     if (not systemExcluded or allowSystemPackageUpload) and  (preferSystem or systemREMatches):
       requested_version = resolve_version(spec, defaults, "unavailable", "unavailable")
       cmd = "REQUESTED_VERSION={version}\n{check}".format(

--- a/tests/testdist/tracking-env.sh
+++ b/tests/testdist/tracking-env.sh
@@ -1,0 +1,6 @@
+package: tracking-env
+version: "1.0"
+track_env:
+  TRACKED_ENV: echo "$TRACKED_ENV"
+---
+echo Building with $TRACKED_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,13 @@ commands =
     sh -c 'coverage run --source={toxinidir} -a {toxinidir}/bitsBuild -c {toxinidir}/tests/testdist build broken5 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Missing package"'
     sh -c 'coverage run --source={toxinidir} -a {toxinidir}/bitsBuild -c {toxinidir}/tests/testdist build broken6 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "while scanning a quoted scalar"'
     sh -c 'coverage run --source={toxinidir} -a {toxinidir}/bitsBuild -c {toxinidir}/tests/testdist build broken7 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Malformed entry prefer_system"'
+    # This should check that we build different packages depending on the track_env
+    sh -c 'TRACKED_ENV=foo coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build tracking-env --force-unknown-architecture --no-system --disable GCC-Toolchain --debug 2>&1 | tee /dev/stderr | grep "Building with foo"'
+    sh -c 'TRACKED_ENV=bar coverage run --source={toxinidir} -a  {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build tracking-env --force-unknown-architecture --no-system --disable GCC-Toolchain --debug 2>&1 | tee /dev/stderr | grep "Building with bar"'
+    # Fake the development package
+    rm -fr tracking-env
+    git clone -b alibuild_CI --depth 1 https://github.com/alisw/alidist tracking-env
+    sh -c 'TRACKED_ENV=bar coverage run --source={toxinidir} -a  {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build tracking-env --force-unknown-architecture --no-system --disable GCC-Toolchain --debug 2>&1 | tee /dev/stderr | grep "Building with bar"'
 
     # Make sure that etc/profile.d/init.sh is re-written properly, even if the package build overwrites it.
     # In particular, AliEn-Runtime does this, so we must handle this.


### PR DESCRIPTION
A recipe can now provide a dict in `track_env` where the
key is the name of an environment variable and the value
is a command which is executed to fill such environment variable.

This can be used to track system properties or environment variables
without having to resort to a system package.

Ported from aliBuild
