### PR TITLE
CVMFS support: make it look like we are running from the local build

### DIFF
--- a/bits_helpers/sync.py
+++ b/bits_helpers/sync.py
@@ -357,7 +357,8 @@ class CVMFSRemoteSync:
       # Create the dummy tarball, if it does not exists
       test -f "{workDir}/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball" && continue
       mkdir -p "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}"
-      ln -sf "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}"
+      find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -name etc -maxdepth 1 -mindepth 1 -exec ln -sf {} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \;
+      cp -fr "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version/etc" "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/etc"
       mkdir -p "{workDir}/TARS/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash"
       tar -C "{workDir}/INSTALLROOT/$pkg_hash" -czf "{workDir}/TARS/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball" .
       rm -rf "{workDir}/INSTALLROOT/$pkg_hash"


### PR DESCRIPTION
By copying etc/profile.d/init.sh, rather than linking it, sourceing the
environment behaves like a local package even if in reality things come
from CVMFS via symlinks.

Kudos to @smuzaffar for the idea.

Ported from alisw/alibuild#939