### PR TITLE
move defaults arg from build_parser to parser

### DIFF
--- a/bits_helpers/args.py
+++ b/bits_helpers/args.py
@@ -404,16 +404,17 @@ On Mac, 1-2 latest supported OSX versions:
 S3_SUPPORTED_ARCHS = "slc7_x86-64", "slc8_x86-64", "ubuntu2004_x86-64", "ubuntu2204_x86-64", "ubuntu2404_x86-64", "slc9_x86-64", "slc9_aarch64"
 
 def finaliseArgs(args, parser):
-  
+
   # Nothing to finalise for version or analytics
   # if args.action in ["version", "analytics", "architecture"]:
   if args.action in ["version", "architecture"]:
     return args
 
-  if "::" in args.defaults:
-    args.defaults,args.xdefaults = args.defaults.split("::")
-  else:
-    args.xdefaults = None
+  if hasattr(args, "defaults"):
+    if "::" in args.defaults:
+      args.defaults,args.xdefaults = args.defaults.split("::")
+    else:
+      args.xdefaults = None
 
   # --architecture can be specified in both clean and build.
   if args.action in ["build", "clean"] and not args.architecture:

--- a/bits_helpers/build.py
+++ b/bits_helpers/build.py
@@ -494,7 +494,6 @@ def doBuild(args, parser):
   (err, overrides, taps) = parseDefaults(args.disable,
                                         defaultsReader, debug)
   dieOnError(err, err)
-
   makedirs(join(workDir, "SPECS"), exist_ok=True)
 
   # If the bits workdir contains a .sl directory, we use Sapling as SCM.

--- a/bits_helpers/deps.py
+++ b/bits_helpers/deps.py
@@ -14,7 +14,7 @@ def doDeps(args, parser):
 
   # Resolve all the package parsing boilerplate
   specs = {}
-  defaultsReader = lambda: readDefaults(args.configDir, args.defaults, parser.error, args.architecture. args.xdefaults)
+  defaultsReader = lambda: readDefaults(args.configDir, args.defaults, parser.error, args.architecture, args.xdefaults)
   (err, overrides, taps) = parseDefaults(args.disable, defaultsReader, debug)
   with DockerRunner(args.dockerImage, args.docker_extra_args) as getstatusoutput_docker:
     systemPackages, ownPackages, failed, validDefaults = \

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -279,7 +279,8 @@ class BuildTestCase(unittest.TestCase):
             fetchRepos=False,
             forceTracked=False,
             plugin="legacy",
-            makeflow=False
+            makeflow=False,
+            xdefaults=None
         )
 
         def mkcall(args):

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -65,7 +65,8 @@ class DepsTestCase(unittest.TestCase):
                          outdot="/tmp/out.dot",
                          outgraph="/tmp/outgraph.pdf",
                          package="AliRoot",
-                         defaults="release")
+                         defaults="release",
+                         xdefaults=None)
 
 
         def fake_exists(n):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -90,7 +90,8 @@ class DoctorTestCase(unittest.TestCase):
                      noSystem="*",
                      architecture="osx_x86-64",
                      disable=[],
-                     defaults="release")
+                     defaults="release",
+                     xdefaults=None)
 
     # What to call (longer names deprecated in Python 3.5+)
     if not hasattr(self, "assertRegex"):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -47,7 +47,8 @@ class InitTestCase(unittest.TestCase):
         defaults = "release",
         dryRun = True,
         fetchRepos = False,
-        architecture = "slc7_x86-64"
+        architecture = "slc7_x86-64",
+        xdefaults = None
       )
       self.assertRaises(SystemExit, doInit, args)
       self.assertEqual(mock_info.mock_calls, [call('This will initialise local checkouts for %s\n--dry-run / -n specified. Doing nothing.', 'zlib,AliRoot')])
@@ -86,7 +87,8 @@ class InitTestCase(unittest.TestCase):
         defaults = "release",
         dryRun = False,
         fetchRepos = False,
-        architecture = "slc7_x86-64"
+        architecture = "slc7_x86-64",
+        xdefaults = None
       )
       doInit(args)
       self.assertEqual(mock_git.mock_calls, CLONE_EVERYTHING)


### PR DESCRIPTION
tests did not have args.defaults in their Namespace - this is a draft commit, just to see if this is the only problem and this fixes it