### PR TITLE
support for inheriting package recepies and improved generated packages

### DIFF
--- a/bits
+++ b/bits
@@ -195,21 +195,22 @@ function configBits() {
 
 config_file=""
 
-for ((i=0;i<$ARGC;i++));
-do
+for ((i=0;i<$ARGC;i++)); do
     arg=${ARGV[$i]}
     opt=${arg%%=*}
     val=${arg##*=}
     case $opt in
        --config)
           config_file=$val
-       ;;   
+       ;;
        *)
+         new_args+=("$arg")
          ;;
    esac
 done
 
-configBits $config_file
+configBits "$config_file"
+set -- "${new_args[@]}"
 
 for arg in $@
 do

--- a/bits_helpers/build.py
+++ b/bits_helpers/build.py
@@ -547,7 +547,9 @@ def doBuild(args, parser):
              "The following packages are system requirements and could not be found:\n\n- %s\n\n"
              "Please run:\n\n\tbitsDoctor --defaults %s %s\n\nto get a full diagnosis." %
              ("\n- ".join(sorted(failed)), args.defaults, " ".join(args.pkgname)))
-
+  
+  banner("Configured directory:\n%s", os.path.abspath(args.configDir))
+  banner("Package Recipe will be searched in the following order \n%s", os.environ.get("BITS_PATH"))
   for x in specs.values():
     x["requires"] = [r for r in x["requires"] if r not in args.disable]
     x["build_requires"] = [r for r in x["build_requires"] if r not in args.disable]

--- a/bits_helpers/utilities.py
+++ b/bits_helpers/utilities.py
@@ -495,7 +495,7 @@ def parseRecipe(reader, generatePackages=None, visited=None):
     if spec and "from" in spec:
       basename = os.path.basename(getattr(reader, "url", "") or "")
       filename = basename[:-3] if basename.endswith(".sh") else basename
-      repoDir = os.path.abspath(os.environ.get("BITS_REPO_DIR"))
+      repoDir = os.environ.get("BITS_REPO_DIR")
       if visited is None:
         visited = []
       if spec["from"] in visited:


### PR DESCRIPTION
Thanks to @akritkbehera , this PR has the following improvements

# Variable expansion in resolve_tag:
The following is now supported so we can have numerical version of PKG_VERSION without having to repeat ourself it in tag
  ```
  package: demo
  version: 2.1.2
  tag: v%(version)s
  ```

#  Fixed repo directory
There was wrong path being constructed if configuration file is passed which was being interpreted as folder. Previously running bits build demo --config=bits.rc led to a path `repositories/bits.rc/general.bits/defaults-release.sh`. Now this resolves to `repositories/general.bits/defaults-release.sh`

# Improved Generated packages
Search for all generated packages in all repositories and not just the first one

#  YAML Merge & Inheritance Behavior for Recipes

This PR introduces structured **merge and inheritance behavior** for YAML-based recipes.

The goal is to enable field-level control with the following policies:

- `merge`: combine fields from parent and child.
- `remove`: exclude fields from parent.
- `inherit`: forcibly inherit specific fields from parent even if overridden.

---

###  Base: `general.bits`

```yaml
package: demo
version: vGeneral
sources: 
 - www.xyz-%(version)s.tar.gz
source:
 - xyz.tar.gz
variables:
  bar: from_cms.bits
  foo: from_general.bits
---
<Recipe From General>
```
```yaml
#package demo.sh
from: general.bits
version: vCMS
variables:
  bar: from_cms.bits
merge_policy:
 - merge: variables
 - remove: env
# - inherit: source
---
# Resulting Recipe (after merge/inheritance resolution)
package: demo
version: vCMS
variables:
  foo: from_general.bits
sources: 
 - www.xyz-%(version)s.tar.gz
env:
  general: general
---
<Build Recipe mentioned General>
```