### PR TITLE
Fix for ProgressPrint output when --resource-monitor is ON

### DIFF
--- a/bits_helpers/build.py
+++ b/bits_helpers/build.py
@@ -487,7 +487,7 @@ def runBuildCommand(scheduler, p, specs, args, build_command, cachedTarball, scr
       args.develPrefix if "develPrefix" in args and spec["is_devel_pkg"] else spec["version"])
     )
   if args.resourceMonitoring:
-    err, out = run_monitor_on_command(build_command, "%s/%s.json" % (scriptDir, p))
+    err = run_monitor_on_command(build_command, "%s/%s.json" % (scriptDir, p), printer=progress)
   else:
     err = execute(build_command, printer=progress)
   if args.builders==1:

--- a/bits_helpers/cmd.py
+++ b/bits_helpers/cmd.py
@@ -56,6 +56,10 @@ def getstatusoutput(command, timeout=None, cwd=None):
 
 def execute(command, printer=debug, timeout=None):
   popen = Popen(command, shell=isinstance(command, str), stdout=PIPE, stderr=STDOUT)
+  return monitor_progress(popen, printer, timeout)
+
+
+def monitor_progress(popen, printer=debug, timeout=None):
   start_time = time.time()
   for line in iter(popen.stdout.readline, b""):
     printer("%s", decode_with_fallback(line).strip("\n"))


### PR DESCRIPTION
This change fixes the `ProgressPrint` output  during the build phase if `--resource-monitor` is ON. Previous implementation of `run_monitor_on_command` (introduced in #54) was capturing all the output and no message was printed on the screen when packages are built in serial/default mode[a] but this change now properly calls `ProgressPrint` during  resource monitoring[b] too.

[a] `bits build --resource-monitor  -c cms.bits dummy-pkg0` output without this change
```
...
==> Packages will be built in the following order:
     - dummy-pkg0@1.0

==> Build of dummy-pkg0 successfully completed on `cmsdev40.cern.ch'.
```

[b] `bits build --resource-monitor  -c cms.bits dummy-pkg0` output with this change
``` 
==> Packages will be built in the following order:
     - dummy-pkg0@1.0
==> Compiling defaults-release@v1 (use --debug for full output): done
==> Compiling dummy-pkg0@1.0 (use --debug for full output): done

==> Build of dummy-pkg0 successfully completed on `cmsdev40.cern.ch'.
```