### PR TITLE
Fix validateDefaults

### DIFF
--- a/bits_helpers/build.py
+++ b/bits_helpers/build.py
@@ -757,13 +757,13 @@ def doBuild(args, parser):
                      taps                    = taps,
                      log                     = debug)
 
-  dieOnError(validDefaults and args.defaults not in validDefaults,
+  dieOnError(validDefaults and any(d not in validDefaults for d in args.defaults),
              "Specified default `%s' is not compatible with the packages you want to build.\n"
-             "Valid defaults:\n\n- %s" % (args.defaults, "\n- ".join(sorted(validDefaults or []))))
+             "Valid defaults:\n\n- %s" % ("::".join(args.defaults), "\n- ".join(sorted(validDefaults or []))))
   dieOnError(failed,
              "The following packages are system requirements and could not be found:\n\n- %s\n\n"
              "Please run:\n\n\tbitsDoctor --defaults %s %s\n\nto get a full diagnosis." %
-             ("\n- ".join(sorted(failed)), args.defaults, " ".join(args.pkgname)))
+             ("\n- ".join(sorted(failed)), "::".join(args.defaults), " ".join(args.pkgname)))
   
   banner("Configured directory:\n%s", os.path.abspath(args.configDir))
   banner("Package Recipe will be searched in the following order \n%s", os.environ.get("BITS_PATH"))

--- a/bits_helpers/deps.py
+++ b/bits_helpers/deps.py
@@ -39,8 +39,8 @@ def doDeps(args, parser):
                      taps                    = taps,
                      log                     = debug)
   
-  dieOnError(validDefaults and args.defaults not in validDefaults,
-             "Specified default `%s' is not compatible with the packages you want to build.\n" % args.defaults +
+  dieOnError(validDefaults and any(d not in validDefaults for d in args.defaults),
+             "Specified default `%s' is not compatible with the packages you want to build.\n" % "::".join(args.defaults) +
              "Valid defaults:\n\n- " +
              "\n- ".join(sorted(validDefaults)))
 

--- a/bits_helpers/doctor.py
+++ b/bits_helpers/doctor.py
@@ -186,7 +186,7 @@ def doDoctor(args, parser):
            "Look at the error messages above to get hints on what packages you need to install separately.",
            "\n- ".join(failed))
     exitcode = 1
-  if validDefaults and args.defaults not in validDefaults:
+  if validDefaults and any(d not in validDefaults for d in args.defaults):
     banner("The list of packages cannot be built with the defaults you have specified.\n"
            "List of valid defaults:\n\n- %s\n\n"
            "Use the `--defaults' switch to specify one of them.",

--- a/bits_helpers/init.py
+++ b/bits_helpers/init.py
@@ -61,8 +61,8 @@ def doInit(args):
                                          overrides=overrides,
                                          taps=taps,
                                          log=debug)
-  dieOnError(validDefaults and args.defaults not in validDefaults,
-             "Specified default `%s' is not compatible with the packages you want to build.\n" % args.defaults +
+  dieOnError(validDefaults and any(d not in validDefaults for d in args.defaults),
+             "Specified default `%s' is not compatible with the packages you want to build.\n" % "::".join(args.defaults) +
              "Valid defaults:\n\n- " +
              "\n- ".join(sorted(validDefaults)))
 

--- a/bits_helpers/utilities.py
+++ b/bits_helpers/utilities.py
@@ -225,11 +225,13 @@ def validateDefaults(finalPkgSpec, defaults):
   nonStringDefaults = [x for x in validDefaults if not type(x) == str]
   if nonStringDefaults:
     return (False, "valid_defaults needs to be a string or a list of strings. Found %s." % nonStringDefaults, [])
-  if defaults in validDefaults:
+  defaultsList = asList(defaults)
+  invalidDefaults = [d for d in defaultsList if d not in validDefaults]
+  if not invalidDefaults:
     return (True, "", validDefaults)
-  return (False, "Cannot compile %s with `%s' default. Valid defaults are\n%s" % 
+  return (False, "Cannot compile %s with `%s' default. Valid defaults are\n%s" %
                   (finalPkgSpec["package"],
-                   defaults,
+                   ", ".join(invalidDefaults),
                    "\n".join([" - " + x for x in validDefaults])), validDefaults)
 
 

--- a/tests/test_parseRecipe.py
+++ b/tests/test_parseRecipe.py
@@ -113,7 +113,7 @@ class TestRecipes(unittest.TestCase):
     self.assertEqual(ok, True)
     ok, out, validDefaults = validateDefaults({"package": "foo","valid_defaults": ["o2", "o2-dataflow"]}, "release")
     self.assertEqual(ok, False)
-    self.assertEqual(out, 'Cannot compile foo with `release\' default. Valid defaults are\n - o2\n - o2-dataflow')
+    self.assertEqual(out, "Cannot compile foo with `release' default. Valid defaults are\n - o2\n - o2-dataflow")
     ok, out, validDefaults = validateDefaults({"package": "foo","valid_defaults": ["o2", "o2-dataflow"]}, "o2")
     self.assertEqual(ok, True)
     ok, out, validDefaults = validateDefaults({"package": "foo","valid_defaults": "o2-dataflow"}, "o2")


### PR DESCRIPTION
Regression from e4e1e51

Handle list input for defaults parameter after str->list change.
Fix all checks of `args.defaults in validDefaults` to iterate over list.
