### PR TITLE
Support for using host workdir inside container; change default container workdir to /container/bits/sw

### DIFF
--- a/bits_helpers/args.py
+++ b/bits_helpers/args.py
@@ -140,6 +140,9 @@ def doParseArgs():
                             help=("Command-line arguments to pass to 'docker run'. "
                                   "Passed through verbatim -- separate multiple arguments "
                                   "with spaces, and make sure quoting is correct! Implies --docker."))
+  build_docker.add_argument("--container-use-workdir", dest="containerUseWorkDir", action="store_true", default=False,
+                            help="Use the host work directory inside container. "
+                                 "By default it uses /container/bits/sw directory inside container.")
   build_docker.add_argument("-v", dest="volumes", action="append", default=[],
                             help=("Additional volume to be mounted inside the Docker container, if one is used. "
                                   "May be specified multiple times. Passed verbatim to 'docker run'."))

--- a/bits_helpers/build_template.sh
+++ b/bits_helpers/build_template.sh
@@ -224,7 +224,7 @@ PH=${PKGHASH}
 PKG_DIR="$WORK_DIR"
 EoF
 
-cp "${BITS_SCRIPT_DIR}/relocate-me.sh" "$INSTALLROOT/"
+install "${BITS_SCRIPT_DIR}/bits_helpers/relocate-me.sh" "$INSTALLROOT/"
 
 # Always relocate the modulefile (if present) so that it works also in devel mode.
 if [[ ! -s "$INSTALLROOT/etc/profile.d/.bits-relocate" && -f "$INSTALLROOT/etc/modulefiles/$PKGNAME" ]]; then

--- a/bits_helpers/relocate-me.sh
+++ b/bits_helpers/relocate-me.sh
@@ -4,8 +4,10 @@ source ${THISDIR}/etc/profile.d/.bits-pkginfo
 INSTALL_BASE=$(echo $THISDIR | sed "s|/$PP$||")
 if [[ -s ${THISDIR}/etc/profile.d/.bits-relocate ]] ; then
   for f in $(cat ${THISDIR}/etc/profile.d/.bits-relocate) ; do
-    sed -i -e "s|${PKG_DIR}/INSTALLROOT/$PH|$INSTALL_BASE|g;s|${PKG_DIR}|$INSTALL_BASE|g" "${THISDIR}/$f"
+    sed -i.unrelocated -e "s|${PKG_DIR}/INSTALLROOT/$PH|$INSTALL_BASE|g;s|${PKG_DIR}|$INSTALL_BASE|g" "${THISDIR}/$f"
+    rm -f "${THISDIR}/${f}.unrelocated"
   done
 fi
-sed -i -e "s|^PKG_DIR=.*|PKG_DIR="${INSTALL_BASE}"|" $THISDIR/etc/profile.d/.bits-pkginfo
+sed -i.unrelocated -e "s|^PKG_DIR=.*|PKG_DIR="${INSTALL_BASE}"|" "$THISDIR/etc/profile.d/.bits-pkginfo"
+rm -f "$THISDIR/etc/profile.d/.bits-pkginfo.unrelocated"
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -274,6 +274,7 @@ class BuildTestCase(unittest.TestCase):
             docker=False,
             dockerImage=None,
             docker_extra_args=["--network=host"],
+            containerWorkDir=False,
             architecture=TEST_ARCHITECTURE,
             workDir="/sw",
             pkgname=["root"],


### PR DESCRIPTION
This PR proposes to change the default build location when docker is used. Currently build with docker uses `/sw` and the new relocate all change will try to relocate all file with `/sw` in them. As `/sw` is very generic so there is a good chance that relocation script can do unwanted changes. This PR proposes to change default workdir inside container to `/container/bits/sw` e.g. we mount `<host>/workdir` to `/container/bits/sw`.

A new command-line option `--container-use-workdir` is also added which will mount `<host>/workdir`  to `<host>/workdir` inside container. This allows to have local packages build with correct path and one should be able to use them directly (on correct OS/ARCH host) or start a container without explicitly mounting `<host>/workdir`  to some magic `/container/bits/sw` path.