### PR TITLE
[O2-6382] Add ref_match_rule property to control fetched git branches

### DIFF
--- a/bits_helpers/workarea.py
+++ b/bits_helpers/workarea.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 
 from bits_helpers.log import dieOnError, debug, error
 from bits_helpers.download import download
-from bits_helpers.utilities import call_ignoring_oserrors, symlink, short_commit_hash
+from bits_helpers.utilities import call_ignoring_oserrors, symlink, short_commit_hash, asList
 
 FETCH_LOG_NAME = "fetch-log.txt"
 
@@ -115,7 +115,8 @@ def updateReferenceRepo(referenceSources, p, spec,
     cmd = scm.cloneReferenceCmd(spec["source"], referenceRepo, usePartialClone)
     logged_scm(scm, p, referenceSources, cmd, ".", allowGitPrompt)
   elif fetch:
-    cmd = scm.fetchCmd(spec["source"], "+refs/tags/*:refs/tags/*", "+refs/heads/*:refs/heads/*")
+    ref_match_rule = asList(spec.get("ref_match_rule", ["+refs/tags/*:refs/tags/*", "+refs/heads/*:refs/heads/*"]))
+    cmd = scm.fetchCmd(spec["source"], *ref_match_rule)
     logged_scm(scm, p, referenceSources, cmd, referenceRepo, allowGitPrompt)
 
   return referenceRepo  # reference is read-write

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -63,6 +63,29 @@ class WorkareaTestCase(unittest.TestCase):
 
     @patch("os.path.exists")
     @patch("os.makedirs")
+    @patch("codecs.open")
+    @patch("bits_helpers.git.git")
+    @patch("bits_helpers.workarea.is_writeable", new=MagicMock(return_value=True))
+    def test_reference_sources_updated_custom_refspec(self, mock_git, mock_open, mock_makedirs, mock_exists):
+        """Check mirrors are updated with custom refspec when provided."""
+        mock_exists.return_value = True
+        mock_git.return_value = 0, "sentinel output"
+        mock_open.return_value = MagicMock(
+            __enter__=lambda *args, **kw: MagicMock(
+                write=lambda output: self.assertEqual(output, "sentinel output")))
+        spec = MOCK_SPEC.copy()
+        spec["ref_match_rule"] = ["+refs/heads/master:refs/heads/master"]
+        updateReferenceRepoSpec(referenceSources="sw/MIRROR", p="AliRoot",
+                                spec=spec, fetch=True)
+        mock_exists.assert_called_with("%s/sw/MIRROR/aliroot" % getcwd())
+        mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd(), exist_ok=True)
+        mock_git.assert_called_once_with([
+            "fetch", "-f", "--prune", "--filter=blob:none", spec["source"], "+refs/heads/master:refs/heads/master",
+        ], directory="%s/sw/MIRROR/aliroot" % getcwd(), check=False, prompt=True)
+        self.assertEqual(spec.get("reference"), "%s/sw/MIRROR/aliroot" % getcwd())
+
+    @patch("os.path.exists")
+    @patch("os.makedirs")
     @patch("bits_helpers.git")
     @patch("bits_helpers.workarea.is_writeable", new=MagicMock(return_value=False))
     def test_reference_sources_not_writable(self, mock_git, mock_makedirs, mock_exists):


### PR DESCRIPTION
Ported from alisw/alibuild#991
