### PR TITLE
Fix defaults usage as string

### DIFF
--- a/bits_helpers/build.py
+++ b/bits_helpers/build.py
@@ -1105,7 +1105,7 @@ def doBuild(args, parser):
       develPrefix = possibleDevelPrefix
 
     if possibleDevelPrefix:
-      spec["build_family"] = "{}-{}".format(possibleDevelPrefix, args.defaults)
+      spec["build_family"] = "{}-{}".format(possibleDevelPrefix, "_".join(args.defaults))
     else:
       spec["build_family"] = "_".join(args.defaults)
     if spec["package"] == mainPackage:


### PR DESCRIPTION
Currently the directories inside sw/$ARCHITECTURE/$PACKAGE are
unproperly named.

Regression from #29 

```
'latest-slc9_x86-64-['\''o2'\'']
```
