### PR TITLE
Bug with `force_revision`

### DIFF
--- a/bits_helpers/build.py
+++ b/bits_helpers/build.py
@@ -295,6 +295,8 @@ def storeHashes(package, specs, considerRelocation):
 
   for key in ("recipe", "version", "package"):
     h_all(spec.get(key, "none"))
+  if "force_revision" in spec:
+    h_all("force_revision:" + str(spec["force_revision"]))
 
   # pkg_family changes the installation path (ARCH/FAMILY/PKG/VER vs
   # ARCH/PKG/VER), so tarballs built with different family settings are


### PR DESCRIPTION
If force_revision is not hashed then we face an unexpected issue.
- We have a package built without it and have it as tarball.
- We add `force_revision` and tries to unpack the previous built package.
- It fails with an error as build_template.sh expects it to be a new location (due to `force_revision`).